### PR TITLE
[NIT] Fix timezone for tutorial timeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 At [SciPy](https://www.scipy2023.scipy.org) in Austin, Texas
 
-**Mon 10 July 2023, 1:30–5:30 pm (EST, Chicago, local time), Classroom 202**
+**Mon 10 July 2023, 1:30–5:30 pm (CDT, Chicago, local time), Classroom 202**
 
 - Please also check the official [Tutorial Schedule](https://cfp.scipy.org/2023/talk/8BZN3E/) for updates.
 


### PR DESCRIPTION
Nitpick -- Central Daylight happens to be the same UTC-5 as Eastern Standard, but Austin is on Central time.

Some folks might see the "E" and end up off by an hour & confused.